### PR TITLE
Plugin reporting

### DIFF
--- a/statick_tool/config.py
+++ b/statick_tool/config.py
@@ -45,9 +45,7 @@ class Config(object):
         return self.get_enabled_plugins(level, "discovery")
 
     def get_enabled_reporting_plugins(self, level):
-        """
-        Get what reporting plugins are enabled for a certain level.
-        """
+        """Get what reporting plugins are enabled for a certain level."""
         return self.get_enabled_plugins(level, "reporting")
 
     def get_plugin_config(self, plugin_type, plugin, level, key, default=None):  # pylint: disable=too-many-arguments

--- a/statick_tool/plugins/reporting/write_file_reporting_plugin.py
+++ b/statick_tool/plugins/reporting/write_file_reporting_plugin.py
@@ -22,11 +22,18 @@ class WriteFileReportingPlugin(ReportingPlugin):
             issues (:obj:`dict` of :obj:`str` to :obj:`Issue`): The issues
                 found by the Statick analysis, keyed by the tool that found
                 them.
-            level: (:obj:`str`): Name of the level used in the scan
+            level: (:obj:`str`): Name of the level used in the scan.
         """
         # We _should_ be in output_dir already, but let's be safe about it
         output_dir = os.path.join(self.plugin_context.args.output_directory,
                                   package.name + "-" + level)
+
+        if not os.path.isdir(output_dir):
+            os.mkdir(output_dir)
+        if not os.path.isdir(output_dir):
+            print("Unable to create output directory at {}!".format(
+                output_dir))
+            return None, False
 
         output_file = os.path.join(output_dir,
                                    package.name + "-" + level + ".statick")

--- a/statick_ws
+++ b/statick_ws
@@ -101,6 +101,7 @@ def main():  # pylint: disable=too-many-locals, too-many-branches, too-many-stat
 
     # Make a dummy plugincontext as well
     plugin_context = PluginContext(args, None, None)
+    plugin_context.args.output_directory = parsed_args.output_directory
 
     if len(enabled_reporting_plugins) == 0:
         enabled_reporting_plugins = list(available_reporting_plugins)


### PR DESCRIPTION
I had some issues with running `statick_ws` where the overall report would error out and the tool would not finish running. I tracked it down to the report plugin for writing to a file not being able to create the output directories. I feel like what I have done is a bit hacky and might mask some future bugs. With these changes I can run `statick_ws` successfully. Feel free to accept these as-is or to fix the problem in a more robust way if you see one.